### PR TITLE
Issue #1: Add wp-dev-lib, and configuration files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,1 @@
+dev-lib/.editorconfig

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+dev-lib/.eslintignore

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,1 @@
+dev-lib/.eslintrc

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "dev-lib"]
+	path = dev-lib
+	url = https://github.com/xwp/wp-dev-lib.git
+	branch = master

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,1 @@
+dev-lib/.jscsrc

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,3 @@
+**/*.min.js
+**/node_modules/**
+**/vendor/**

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,1 @@
+dev-lib/.jshintrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+sudo: false
+dist: precise
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+
+cache:
+  directories:
+    - node_modules
+    - vendor
+    - $HOME/phpunit-bin
+
+language:
+  - php
+  - node_js
+
+php:
+  - 5.4
+  - 5.6
+  - 7.0
+
+env:
+  - WP_VERSION=latest WP_MULTISITE=0
+  - WP_VERSION=latest WP_MULTISITE=1
+  - WP_VERSION=trunk WP_MULTISITE=0
+  - WP_VERSION=trunk WP_MULTISITE=1
+
+install:
+  - nvm install 6 && nvm use 6
+  - export DEV_LIB_PATH=dev-lib
+  - if [ ! -e "$DEV_LIB_PATH" ] && [ -L .travis.yml ]; then export DEV_LIB_PATH=$( dirname $( readlink .travis.yml ) ); fi
+  - if [ ! -e "$DEV_LIB_PATH" ]; then git clone https://github.com/xwp/wp-dev-lib.git $DEV_LIB_PATH; fi
+  - source $DEV_LIB_PATH/travis.install.sh
+
+script:
+  - source $DEV_LIB_PATH/travis.script.sh
+
+after_script:
+  - source $DEV_LIB_PATH/travis.after_script.sh

--- a/package.json
+++ b/package.json
@@ -19,5 +19,11 @@
   "bugs": {
     "url": "https://github.com/kienstra/bootstrap-widget-styling/issues"
   },
-  "homepage": "https://github.com/kienstra/bootstrap-widget-styling#readme"
+  "homepage": "https://github.com/kienstra/bootstrap-widget-styling#readme",
+  "devDependencies": {
+    "eslint": "^4.15.0",
+    "grunt-cli": "^1.2.0",
+    "jscs": "^3.0.7",
+    "jshint": "^2.9.5"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "bootstrap-widget-styling",
+  "version": "1.0.4",
+  "description": "WordPress plugin to modify the markup of widgets for Bootstrap. ",
+  "main": "index.js",
+  "scripts": {
+    "test": "test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kienstra/bootstrap-widget-styling.git"
+  },
+  "keywords": [
+    "WordPress",
+    "widget"
+  ],
+  "author": "@ryankienstra",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/kienstra/bootstrap-widget-styling/issues"
+  },
+  "homepage": "https://github.com/kienstra/bootstrap-widget-styling#readme"
+}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Coding Standards for Bootstrap Widget Styling Plugin">
+	<description>Sniffs for plugin and VIP WordPress standards</description>
+
+	<rule ref="WordPress-Core" />
+	<rule ref="WordPress-Docs" />
+	<rule ref="WordPress-VIP" />
+	<rule ref="WordPress-Extra" />
+	<rule ref="WordPress.WP.I18n" />
+	<rule ref="WordPress.VIP.ValidatedSanitizedInput" />
+
+	<arg name="extensions" value="php"/>
+
+	<!-- Show sniff codes in all reports -->
+	<arg value="s"/>
+
+	<!-- Allow invoking just `phpcs` on command line without assuming STDIN for file input. -->
+	<file>.</file>
+
+	<exclude-pattern>*/dev-lib/*</exclude-pattern>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,1 @@
+dev-lib/phpunit-plugin.xml


### PR DESCRIPTION
This pull request for Issue #1 adds [wp-dev-lib](https://github.com/xwp/wp-dev-lib) as as submodule. It also adds configuration files, like `phpunit.xml.dist` and `phpcs.xml`. This is now ready to install the [pre-commit](https://github.com/xwp/wp-dev-lib/blob/master/pre-commit) hook.