### PR TITLE
Issue #20: Display date in 'Recent Posts' widget.

### DIFF
--- a/php/widgets/class-bws-widget-recent-comments.php
+++ b/php/widgets/class-bws-widget-recent-comments.php
@@ -28,12 +28,11 @@ class BWS_Widget_Recent_Comments extends \WP_Widget_Recent_Comments {
 		foreach ( $dom->getElementsByTagName( 'li' ) as $li ) {
 			$anchor = $li->getElementsByTagName( 'a' );
 			if ( $anchor->length > 0 ) {
-				$last_index  = $anchor->length - 1;
-				$list_group .= sprintf( '<a href="%s" class="list-group-item">%s</a>', esc_url( $anchor->item( $last_index )->attributes->getNamedItem( 'href' )->nodeValue ), esc_html( $li->textContent ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
+				$list_group .= sprintf( '<a href="%s" class="list-group-item">%s</a>', esc_url( $anchor->item( $anchor->length - 1 )->attributes->getNamedItem( 'href' )->nodeValue ), esc_html( $li->textContent ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
 			}
 		}
 		$list_group .= '</div>';
-		echo preg_replace( '/<ul.*<\/ul>/', $list_group, $output ); // WPCS: XSS ok.
+		echo preg_replace( '/<ul[\s\S]*<\/ul>/', $list_group, $output ); // WPCS: XSS ok.
 	}
 
 }

--- a/php/widgets/class-bws-widget-recent-comments.php
+++ b/php/widgets/class-bws-widget-recent-comments.php
@@ -27,7 +27,7 @@ class BWS_Widget_Recent_Comments extends \WP_Widget_Recent_Comments {
 		$list_group = '<div class="list-group">';
 		foreach ( $dom->getElementsByTagName( 'li' ) as $li ) {
 			$anchor = $li->getElementsByTagName( 'a' );
-			if ( $anchor->length > 0 ) {
+			if ( ! empty( $anchor->item( $anchor->length - 1 )->attributes->getNamedItem( 'href' )->nodeValue ) ) {
 				$list_group .= sprintf( '<a href="%s" class="list-group-item">%s</a>', esc_url( $anchor->item( $anchor->length - 1 )->attributes->getNamedItem( 'href' )->nodeValue ), esc_html( $li->textContent ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
 			}
 		}

--- a/php/widgets/class-bws-widget-recent-posts.php
+++ b/php/widgets/class-bws-widget-recent-posts.php
@@ -33,12 +33,14 @@ class BWS_Widget_Recent_Posts extends \WP_Widget_Recent_Posts {
 				$post_date_text    = ( isset( $initial_post_date ) && property_exists( $initial_post_date, 'textContent' ) ) ? $initial_post_date->textContent : '';
 				$post_date_element = ! empty( $post_date_text ) ? sprintf( '<span class="post-date label label-primary pull-right">%s</span>', esc_html( $post_date_text ) ) : '';
 				$post_title        = str_replace( $post_date_text, '', $li->textContent );
-				$list_group       .= sprintf(
-					'<a href="%s" class="list-group-item">%s %s</a>',
-					esc_url( $anchor->item( $anchor->length - 1 )->attributes->getNamedItem( 'href' )->nodeValue ),  // phpcs:enable WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
-					esc_html( $post_title ),
-					$post_date_element
-				);
+				if ( ! empty( $anchor->item( $anchor->length - 1 )->attributes->getNamedItem( 'href' )->nodeValue ) ) {
+					$list_group .= sprintf(
+						'<a href="%s" class="list-group-item">%s %s</a>',
+						esc_url( $anchor->item( $anchor->length - 1 )->attributes->getNamedItem( 'href' )->nodeValue ),  // phpcs:enable WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
+						esc_html( $post_title ),
+						wp_kses_post( $post_date_element )
+					);
+				}
 			}
 		}
 

--- a/php/widgets/class-bws-widget-recent-posts.php
+++ b/php/widgets/class-bws-widget-recent-posts.php
@@ -22,8 +22,27 @@ class BWS_Widget_Recent_Posts extends \WP_Widget_Recent_Posts {
 		ob_start();
 		parent::widget( $args, $instance );
 		$output = ob_get_clean();
-		$plugin = Plugin::get_instance();
-		echo $plugin->components->widget_output->reformat( $output ); // WPCS: XSS ok.
-	}
 
+		$dom = new \DOMDocument();
+		$dom->loadHTML( $output );
+		$list_group = '<div class="list-group">';
+		foreach ( $dom->getElementsByTagName( 'li' ) as $li ) {
+			$anchor = $li->getElementsByTagName( 'a' );
+			if ( $anchor->length > 0 ) {
+				$initial_post_date = $li->getElementsByTagName( 'span' )->item( 0 ); // phpcs:disable WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
+				$post_date_text    = ( isset( $initial_post_date ) && property_exists( $initial_post_date, 'textContent' ) ) ? $initial_post_date->textContent : '';
+				$post_date_element = ! empty( $post_date_text ) ? sprintf( '<span class="post-date label label-primary pull-right">%s</span>', esc_html( $post_date_text ) ) : '';
+				$post_title        = str_replace( $post_date_text, '', $li->textContent );
+				$list_group       .= sprintf(
+					'<a href="%s" class="list-group-item">%s %s</a>',
+					esc_url( $anchor->item( $anchor->length - 1 )->attributes->getNamedItem( 'href' )->nodeValue ),  // phpcs:enable WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
+					esc_html( $post_title ),
+					$post_date_element
+				);
+			}
+		}
+
+		$list_group .= '</div>';
+		echo preg_replace( '/<ul[\s\S]*\/ul>/', $list_group, $output ); // WPCS: XSS ok.
+	}
 }

--- a/tests/php/widgets/test-class-bws-widget-recent-posts.php
+++ b/tests/php/widgets/test-class-bws-widget-recent-posts.php
@@ -38,24 +38,44 @@ class Test_BWS_Widget_Recent_Posts extends \WP_UnitTestCase {
 	public function test_widget() {
 		$first_post  = $this->factory()->post->create_and_get();
 		$second_post = $this->factory()->post->create_and_get();
+		$args        = array(
+			'before_title'  => '',
+			'after_title'   => '',
+			'before_widget' => '',
+			'after_widget'  => '',
+		);
+
 		ob_start();
 		$this->instance->widget(
+			$args,
 			array(
-				'before_title'  => '',
-				'after_title'   => '',
-				'before_widget' => '',
-				'after_widget'  => '',
-			),
-			array(
-				'count' => 1,
+				'count' => 5,
 			)
 		);
 		$output = ob_get_clean();
-		$this->assertEquals( 0, strpos( $output, '<div class="list-group">' ) );
-		$this->assertContains( '<a class="list-group-item"', $output );
+
+		$this->assertNotFalse( strpos( $output, '<div class="list-group">' ) );
+		$this->assertContains( 'class="list-group-item"', $output );
 		$this->assertContains( $first_post->post_title, $output );
 		$this->assertContains( $second_post->post_title, $output );
 		$this->assertNotContains( '<ul', $output );
+		$this->assertNotContains( '<span class="post-date label label-primary pull-right', $output );
+
+		// Test for when the 'Display post date?' checkbox is checked.
+		ob_start();
+		$this->instance->widget(
+			$args,
+			array(
+				'show_date' => true,
+				'count'     => 5,
+			)
+		);
+		$output = ob_get_clean();
+
+		$this->assertContains( '<span class="post-date label label-primary pull-right', $output );
+		$this->assertNotFalse( strpos( $output, '<div class="list-group">' ) );
+		$this->assertContains( $first_post->post_title, $output );
+		$this->assertContains( $second_post->post_title, $output );
 	}
 
 }


### PR DESCRIPTION
Before, the logic for the 'Recent Posts' widget post date was in a JS file. But that file is deleted, with the logic ported to PHP.

But I didn't port the date logic. So this PR adds it and corresponding tests.

Closes #20.