### PR TITLE
Increase test coverage to include almost all methods and functions

### DIFF
--- a/tests/php/test-class-widget-output.php
+++ b/tests/php/test-class-widget-output.php
@@ -107,6 +107,7 @@ class Test_Widget_Output extends \WP_UnitTestCase {
 	 * @covers Widget_Output::load_widget_files()
 	 */
 	public function test_load_widget_files() {
+		$this->instance->load_widget_files();
 		foreach ( $this->instance->plugin->widgets as $widget ) {
 			$this->assertTrue( class_exists( __NAMESPACE__ . '\BWS_' . ucwords( str_replace( '-', '_', $widget ), '_' ) ) );
 		}

--- a/tests/test-bootstrap-widget-styling.php
+++ b/tests/test-bootstrap-widget-styling.php
@@ -19,13 +19,13 @@ class Test_Bootstrap_Widget_Styling extends \WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 		wp_maybe_load_widgets();
-		require dirname( __DIR__ ) . '/bootstrap-widget-styling.php';
+		require_once dirname( __DIR__ ) . '/bootstrap-widget-styling.php';
 	}
 
 	/**
 	 * Test main plugin file
 	 *
-	 * @see widget-live-editor.php
+	 * @see bootstrap-widget-styling.php
 	 */
 	public function test_class_exists() {
 		$this->assertTrue( class_exists( __NAMESPACE__ . '\Plugin' ) );


### PR DESCRIPTION
**Pull Request**

This PR for #3 calls `Widget_Output::load_widget_files().` Before, this wasn't called, but it was tested. So the coverage report showed it as not tested.

Now, all functions and methods are tested, other than an anonymous callback function:

<img width="1364" alt="test-coverage" src="https://user-images.githubusercontent.com/4063887/40024895-652af648-5795-11e8-8589-9ade743b032e.png">
