### PR TITLE
Prevent an error with DOMDocument::loadHTML().

### DIFF
--- a/php/widgets/class-bws-widget-recent-comments.php
+++ b/php/widgets/class-bws-widget-recent-comments.php
@@ -21,7 +21,9 @@ class BWS_Widget_Recent_Comments extends \WP_Widget_Recent_Comments {
 	public function widget( $args, $instance ) {
 		ob_start();
 		parent::widget( $args, $instance );
-		$output = ob_get_clean();
+
+		// DOMDocument::loadHTML raises an error in parsing some HTML5 elements, like <aside>.
+		$output = str_replace( 'aside', 'div', ob_get_clean() );
 		$dom    = new \DOMDocument();
 		$dom->loadHTML( $output );
 		$list_group = '<div class="list-group">';

--- a/php/widgets/class-bws-widget-recent-posts.php
+++ b/php/widgets/class-bws-widget-recent-posts.php
@@ -21,9 +21,10 @@ class BWS_Widget_Recent_Posts extends \WP_Widget_Recent_Posts {
 	public function widget( $args, $instance ) {
 		ob_start();
 		parent::widget( $args, $instance );
-		$output = ob_get_clean();
 
-		$dom = new \DOMDocument();
+		// DOMDocument::loadHTML raises an error in parsing some HTML5 elements, like <aside>.
+		$output = str_replace( 'aside', 'div', ob_get_clean() );
+		$dom    = new \DOMDocument();
 		$dom->loadHTML( $output );
 		$list_group = '<div class="list-group">';
 		foreach ( $dom->getElementsByTagName( 'li' ) as $li ) {


### PR DESCRIPTION
There was an error when `DOMDocument::loadHTML()` parsed an `<aside>`:

>Warning: DOMDocument::loadHTML(): Tag aside invalid in Entity, line: 1 in /srv/www/wordpress-default/public_html/wp-content/plugins/bootstrap-widget-styling/php/widgets/class-bws-widget-recent-comments.php on line 26


<img width="1374" alt="error-domdocument" src="https://user-images.githubusercontent.com/4063887/40272997-ccbf1a64-5b7d-11e8-98db-11c80e133f68.png">

That method raises an error in parsing some HTML5 elements, like `<aside>`.

So this replaces that with a `<div>`. The `<aside>` wasn't output in the Bootstrap-formatted markup, so this won't affect the front-end.

