### PR TITLE
Fix issue in Meta widget with RSS links

### DIFF
--- a/php/class-widget-output.php
+++ b/php/class-widget-output.php
@@ -65,6 +65,33 @@ class Widget_Output {
 	}
 
 	/**
+	 * Gets Bootstrap-formatted markup, using \DOMDocument.
+	 *
+	 * This allows iterating through all of the <li> elements.
+	 * And it has a simpler way of finding attributes.
+	 *
+	 * @param string $markup The HTML to reformat.
+	 * @return string $list_group The markup, in a Bootstrap format for <div class="list-group">.
+	 */
+	public function reformat_dom_document( $markup ) {
+		$dom = new \DOMDocument();
+		$dom->loadHTML( $markup );
+		$list_group = '<div class="list-group">';
+		foreach ( $dom->getElementsByTagName( 'li' ) as $li ) {
+			$anchor = $li->getElementsByTagName( 'a' );
+			if ( ! empty( $anchor->item( $anchor->length - 1 )->attributes->getNamedItem( 'href' )->nodeValue ) ) {
+				$list_group .= sprintf(
+					'<a href="%s" class="list-group-item">%s</a>',
+					esc_url( $anchor->item( $anchor->length - 1 )->attributes->getNamedItem( 'href' )->nodeValue ),
+					esc_html( $li->textContent ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
+				);
+			}
+		}
+		$list_group .= '</div>';
+		return $list_group;
+	}
+
+	/**
 	 * Loads the subclass widgets, based on whether their parent classes are present.
 	 *
 	 * Separate from Plugin::load_file() because this checks whether the parent class exists.

--- a/php/widgets/class-bws-widget-meta.php
+++ b/php/widgets/class-bws-widget-meta.php
@@ -22,8 +22,22 @@ class BWS_Widget_Meta extends \WP_Widget_Meta {
 		ob_start();
 		parent::widget( $args, $instance );
 		$output = ob_get_clean();
-		$plugin = Plugin::get_instance();
-		echo $plugin->components->widget_output->reformat( $output ); // WPCS: XSS ok.
+
+		/**
+		 * DOMDocument::loadHTML() raises an error in parsing some HTML5 elements, like <aside> and <section>.
+		 *
+		 * Themes can add HTML5 elements via $args['before_widget'] and $args['before_widget'].
+		 * So this removes them from the markup that DOMDocument::loadHTML() parses.
+		 * The 'before_widget' and 'after_widget' markup will still be part of the final widget markup in the echo statement.
+		 */
+		$markup_to_search = str_replace(
+			array( $args['before_widget'], $args['after_widget'] ),
+			'',
+			$output
+		);
+		$plugin           = Plugin::get_instance();
+		$list_group       = $plugin->components->widget_output->reformat_dom_document( $markup_to_search );
+		echo preg_replace( '/<ul[\s\S]*<\/ul>/', $list_group, $output ); // WPCS: XSS ok.
 	}
 
 }

--- a/php/widgets/class-bws-widget-recent-comments.php
+++ b/php/widgets/class-bws-widget-recent-comments.php
@@ -35,16 +35,8 @@ class BWS_Widget_Recent_Comments extends \WP_Widget_Recent_Comments {
 			'',
 			$output
 		);
-		$dom              = new \DOMDocument();
-		$dom->loadHTML( $markup_to_search );
-		$list_group = '<div class="list-group">';
-		foreach ( $dom->getElementsByTagName( 'li' ) as $li ) {
-			$anchor = $li->getElementsByTagName( 'a' );
-			if ( ! empty( $anchor->item( $anchor->length - 1 )->attributes->getNamedItem( 'href' )->nodeValue ) ) {
-				$list_group .= sprintf( '<a href="%s" class="list-group-item">%s</a>', esc_url( $anchor->item( $anchor->length - 1 )->attributes->getNamedItem( 'href' )->nodeValue ), esc_html( $li->textContent ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
-			}
-		}
-		$list_group .= '</div>';
+		$plugin           = Plugin::get_instance();
+		$list_group       = $plugin->components->widget_output->reformat_dom_document( $markup_to_search );
 		echo preg_replace( '/<ul[\s\S]*<\/ul>/', $list_group, $output ); // WPCS: XSS ok.
 	}
 

--- a/tests/php/test-class-widget-output.php
+++ b/tests/php/test-class-widget-output.php
@@ -102,6 +102,31 @@ class Test_Widget_Output extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test reformat_dom_document().
+	 *
+	 * Uses markup copied from WP_Widget_Meta.
+	 *
+	 * @covers Widget_Output::reformat_dom_document()
+	 */
+	public function test_reformat_dom_document() {
+		ob_start();
+		?>
+		<ul>
+			<?php wp_register(); ?>
+			<li><?php wp_loginout(); ?></li>
+			<li><a href="<?php echo esc_url( get_bloginfo( 'rss2_url' ) ); ?>"><?php esc_html_e( 'Entries <abbr title="Really Simple Syndication">RSS</abbr>' ); ?></a></li>
+			<li><a href="<?php echo esc_url( get_bloginfo( 'comments_rss2_url' ) ); ?>"><?php esc_html_e( 'Comments <abbr title="Really Simple Syndication">RSS</abbr>' ); ?></a></li>
+		</ul>
+		<?php
+		$markup = $this->instance->reformat_dom_document( ob_get_clean() );
+
+		$this->assertEquals( 0, strpos( $markup, '<div class="list-group">' ) );
+		$this->assertContains( 'class="list-group-item"', $markup );
+		$this->assertContains( 'Entries RSS', $markup );
+		$this->assertContains( 'Comments RSS', $markup );
+	}
+
+	/**
 	 * Test load_widget_files().
 	 *
 	 * @covers Widget_Output::load_widget_files()

--- a/tests/php/widgets/test-class-bws-widget-meta.php
+++ b/tests/php/widgets/test-class-bws-widget-meta.php
@@ -41,16 +41,16 @@ class Test_BWS_Widget_Meta extends \WP_UnitTestCase {
 			array(
 				'before_title'  => '',
 				'after_title'   => '',
-				'before_widget' => '',
-				'after_widget'  => '',
+				'before_widget' => '<aside>',
+				'after_widget'  => '</aside>',
 			),
 			array(
 				'count' => 1,
 			)
 		);
 		$output = ob_get_clean();
-		$this->assertEquals( 0, strpos( $output, '<div class="list-group">' ) );
-		$this->assertContains( '<a class="list-group-item"', $output );
+		$this->assertContains( '<div class="list-group">', $output );
+		$this->assertContains( 'class="list-group-item"', $output );
 		$this->assertNotContains( '<ul', $output );
 	}
 


### PR DESCRIPTION
Before, the RSS links in the Meta widget appeared in separate `<li>` elements:

<img width="1359" alt="rss-list-group" src="https://user-images.githubusercontent.com/4063887/40571960-3d34942a-6067-11e8-85e1-69d56341c8c5.png">

So this uses the existing solution with `\DOMDocument`. It also abstracts it into `Widget_Output::reformat_dom_document()`. 

